### PR TITLE
docs: adopt Spec Kitty governance model (constitution, review gates, retrospectives)

### DIFF
--- a/.kittify/memory/constitution.md
+++ b/.kittify/memory/constitution.md
@@ -1,0 +1,109 @@
+# Daily DAP Project Constitution
+
+**Version**: 1.0.0
+**Ratified**: 2026-07-10
+**Applies to**: All missions, features, and contributions (human or AI) in this repository.
+
+This constitution defines the binding principles for the Daily DAP project. Mission plans
+must include a Constitution Check gate that verifies compliance with this document before
+implementation begins (see `kitty-specs/002-daily-dap-quality-benchmarking/plan.md` for the
+gate format). Where a mission conflicts with this constitution, the constitution wins unless
+an amendment is ratified first.
+
+## Principles
+
+### P1. Accessibility is a primary quality metric
+
+- Accessibility is a first-class output of this project, not a secondary check.
+- All published HTML (reports, index pages, archives) must meet WCAG 2.2 AA.
+- Changes that reduce the accessibility of published pages are defects, even when tests pass.
+- Project-specific guidance lives in `ACCESSIBILITY.md` and is binding.
+
+### P2. Published metrics must be reproducible
+
+- Every published number must be derivable from versioned inputs: configuration in
+  `src/config/`, source data references, and code in `src/`.
+- Daily report snapshots are committed under `docs/reports/` so any published day can be
+  audited later.
+- Non-deterministic steps (live scans, remote fetches) must record enough run metadata
+  (run id, date, mode, counts, failures) for a reader to understand what was measured.
+
+### P3. Methodology is transparent
+
+- Scoring, weighting, severity mapping, and impact-estimation methods must be documented in
+  public repository files (`README.md`, `FEATURES.md`, `kitty-specs/`), not only in code.
+- Estimates must be labeled as estimates, with their data sources named (for example the
+  Census ACS disability prevalence data in `src/config/prevalence.yaml`).
+- Known limitations (bot traffic inclusion, sampling limits, scanner gaps) are disclosed
+  next to the numbers they affect.
+
+### P4. AI contributions are disclosed
+
+- AI agents that contribute code, documentation, or planning must update the
+  `## AI Disclosure` section of `README.md`, identifying the tool, version where known,
+  and the nature of the contribution.
+- Tools that were not used must not be listed.
+- AI-generated methodology changes require human review before merge (see P6).
+
+### P5. Open standards and open data are preferred
+
+- Prefer open, documented formats (JSON, YAML, CSV, static HTML) over proprietary ones.
+- Published datasets and reports must remain publicly readable without authentication
+  (see `kitty-specs/001-anonymous-public-access/`).
+- Prefer public, citable upstream sources (DAP, Census ACS, CISA dotgov data) and record
+  the endpoint or dataset vintage used.
+
+### P6. Methodology changes require human review
+
+- Any change to scoring, severity weights, prevalence profiles, traffic windows, sampling,
+  or impact formulas must be reviewed and approved by a human maintainer before it takes
+  effect in published reports.
+- Such changes must update the relevant documentation and, when user-visible behavior
+  changes, the curated behavior specifications (see Governance: BDD linkage).
+
+### P7. Public interest comes first
+
+- The project exists to improve public-facing government services. Decisions are weighed
+  by their effect on people using those services, prioritizing high-traffic pages where
+  regressions affect the most people.
+- Features that serve vanity metrics at the expense of clarity or accuracy are out of scope.
+
+## Governance
+
+### Review gates
+
+Work cannot move to approved status until the documented review gates pass. The gates and
+their meanings are defined in `.kittify/memory/review-gates.md`.
+
+### BDD linkage
+
+The repository maintains curated behavior specifications with stable requirement IDs:
+
+- Feature files: `tests/bdd/features/`
+- Traceability matrix: `tests/bdd/TRACEABILITY.md`
+- Ownership model: `tests/bdd/OWNERS.md`
+
+Whenever user-visible behavior changes, the corresponding behavior specification must be
+reviewed and updated in the same change, and the traceability matrix kept accurate. New
+user-visible behavior requires a new requirement ID.
+
+### Retrospectives
+
+Each completed mission ends with a retrospective using the format in
+`.kittify/memory/retrospective-template.md`. Retrospectives are stored in the mission
+directory as `kitty-specs/<mission>/retrospective.md` and become part of the project's
+institutional memory.
+
+### Mission conventions
+
+Future missions follow the lifecycle model established by
+`kitty-specs/003-spec-kitty-governance-upgrade/`: specify, plan (with Constitution Check),
+tasks, implement, review (gates), accept, retrospective.
+
+### Amendments
+
+- Amendments are proposed as pull requests editing this file, with rationale.
+- A human maintainer must approve amendments; AI agents may draft but not ratify.
+- Version is bumped semantically: clarifications are patch, new or expanded principles are
+  minor, removed or redefined principles are major.
+- Ratified amendments update the version and date at the top of this file.

--- a/.kittify/memory/retrospective-template.md
+++ b/.kittify/memory/retrospective-template.md
@@ -1,0 +1,32 @@
+# Mission Retrospective Template
+
+Copy this template to `kitty-specs/<mission>/retrospective.md` when a mission completes,
+and fill in every field. Retrospectives are part of the project's institutional memory:
+future missions and agents read them to avoid repeating mistakes.
+
+Keep entries factual and specific. Reference files by project-relative path.
+
+```yaml
+mission: kitty-specs/<number>-<slug>/
+completed: YYYY-MM-DD
+wins:
+  - What went well and should be repeated.
+surprises:
+  - What was unexpected (good or bad) and what we learned from it.
+mistakes:
+  - What went wrong, why, and how it was (or should be) corrected.
+governance_changes:
+  - Constitution amendments, new or changed review gates, or process changes
+    that resulted from this mission. Use "none" if there were none.
+future_work:
+  - Follow-up items that were identified but intentionally deferred,
+    with enough context for someone else to pick them up.
+```
+
+## Notes
+
+- Write retrospectives promptly, while context is fresh.
+- If a mistake revealed a gap in the review gates or the constitution, propose the
+  amendment (see `.kittify/memory/constitution.md`, Amendments) and record it under
+  `governance_changes`.
+- Retrospectives are reviewed like any other artifact: they go through a pull request.

--- a/.kittify/memory/review-gates.md
+++ b/.kittify/memory/review-gates.md
@@ -1,0 +1,63 @@
+# Review Gates
+
+**Version**: 1.0.0
+**Applies to**: All work packages and missions in this repository.
+
+Work (a work package, feature, or mission) may only move to **approved** status when every
+applicable gate below passes. Gates are checked during review, before merge to `main`.
+If a gate is not applicable to a change, the reviewer records why.
+
+## Gates
+
+### tests_pass
+
+- `npm test` passes locally or in CI for the change.
+- New behavior has test coverage at the appropriate level (unit, contract, integration,
+  or BDD acceptance), following existing suites under `tests/`.
+
+### bdd_reviewed
+
+- If the change alters user-visible behavior, the curated behavior specifications in
+  `tests/bdd/features/` were reviewed and updated in the same change.
+- `tests/bdd/TRACEABILITY.md` remains accurate: new behavior gets a new requirement ID,
+  changed behavior updates the mapped scenario summary.
+- Ownership expectations in `tests/bdd/OWNERS.md` were respected.
+
+### documentation_updated
+
+- User-facing documentation (`README.md`, `FEATURES.md`, mission artifacts under
+  `kitty-specs/`) reflects the change.
+- Configuration changes are documented next to the configuration files they affect.
+
+### accessibility_reviewed
+
+- Changes to published HTML output were checked against WCAG 2.2 AA and the guidance in
+  `ACCESSIBILITY.md`.
+- Rendering of user-controlled or remote content uses `escapeHtml()` or an equivalent
+  established sanitization path.
+
+### methodology_reviewed
+
+- Changes to scoring, severity weights, prevalence profiles, traffic windows, sampling,
+  or impact formulas were explicitly reviewed and approved by a human maintainer
+  (constitution principle P6).
+- The methodology documentation and any affected estimates or labels were updated.
+
+### ai_disclosure_updated
+
+- If an AI agent contributed to the change, the `## AI Disclosure` section of `README.md`
+  identifies the tool and the nature of the contribution.
+
+## Recording gate results
+
+Reviews record gate outcomes in the pull request (checklist or review comment) using the
+gate names above, for example:
+
+```text
+tests_pass: pass
+bdd_reviewed: n/a (no user-visible behavior change)
+documentation_updated: pass
+accessibility_reviewed: n/a (no HTML output change)
+methodology_reviewed: n/a (no methodology change)
+ai_disclosure_updated: pass
+```

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ This project is transparent about how AI tools have been used throughout its dev
 | OpenAI | gpt-5 | Added a dedicated BDD behavior layer under tests/bdd with curated domain Gherkin features, traceability and ownership docs, step/world guidance, and a pull request checklist for behavior-change governance |
 | OpenAI | gpt-5 (Copilot Coding Agent) | Clarified the Common Accessibility Issues section to state disability-impact values are Census-based estimates and that page-load totals may include bot traffic; added unit-test coverage for the updated language |
 | OpenAI | gpt-5 (Copilot Coding Agent) | Added optional WebPageTest scanner integration (with `WEBPAGETEST_API_KEY`), normalized per-URL WebPageTest metrics/issues, and report-level common performance pain-point aggregation with focused unit tests |
+| Claude (Anthropic) | (via Claude Code) | Governance documentation for issue #210: authored `.kittify/memory/constitution.md`, `.kittify/memory/review-gates.md`, `.kittify/memory/retrospective-template.md`, and mission artifacts under `kitty-specs/003-spec-kitty-governance-upgrade/`; no code changes |
 
 ### Runtime operation
 

--- a/kitty-specs/003-spec-kitty-governance-upgrade/meta.json
+++ b/kitty-specs/003-spec-kitty-governance-upgrade/meta.json
@@ -1,0 +1,10 @@
+{
+  "feature_number": "003",
+  "slug": "003-spec-kitty-governance-upgrade",
+  "friendly_name": "Spec Kitty Governance Upgrade",
+  "mission": "documentation",
+  "source_description": "Adopt current Spec Kitty governance model: constitution, review gates, retrospectives, and future mission conventions (issue #210)",
+  "created_at": "2026-07-10T00:00:00.000000+00:00",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/kitty-specs/003-spec-kitty-governance-upgrade/plan.md
+++ b/kitty-specs/003-spec-kitty-governance-upgrade/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Spec Kitty Governance Upgrade
+
+**Branch**: `003-spec-kitty-governance-upgrade` | **Date**: 2026-07-10 | **Spec**: `kitty-specs/003-spec-kitty-governance-upgrade/spec.md`
+**Input**: Feature specification from `kitty-specs/003-spec-kitty-governance-upgrade/spec.md`
+
+## Summary
+
+Add a binding governance layer to Daily DAP without touching runtime code: a project
+constitution, documented review gates, a mission retrospective template, and lifecycle
+conventions for future missions. All deliverables are markdown documents; no source code,
+tests, or published report outputs change.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation only; no runtime changes
+**Primary Dependencies**: Existing Spec Kitty structure (`.kittify/`, `kitty-specs/`), BDD layer (`tests/bdd/`)
+**Storage**: Versioned markdown in the repository
+**Testing**: `npm test` must still pass unchanged (FR-006); document review via gates
+**Target Platform**: Repository governance (applies to all contributors and agents)
+**Project Type**: Documentation / governance mission
+**Constraints**: ASCII-safe UTF-8 per `.kittify/AGENTS.md`; project-relative path references; no changes to `src/`, `tests/` behavior, or `docs/reports/`
+**Scale/Scope**: Four governance documents plus mission artifacts
+
+## Constitution Check
+
+*GATE: Must pass before implementation.*
+
+- This mission creates the constitution, so the initial check is bootstrap: deliverables
+  were drafted against the principles they define and against issue #210.
+- Gate result: **Pass (bootstrap)**. Future missions check against
+  `.kittify/memory/constitution.md`.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+kitty-specs/003-spec-kitty-governance-upgrade/
+  spec.md          # Feature specification (issue #210 objectives)
+  plan.md          # This file
+  tasks.md         # Work packages
+  meta.json        # Mission metadata
+  tasks/           # Work package prompts
+```
+
+### Governance deliverables (project root)
+
+```text
+.kittify/memory/
+  constitution.md            # Binding principles + amendment process
+  review-gates.md            # Named gates required before approved status
+  retrospective-template.md  # Standard retrospective format
+```
+
+## Design Decisions
+
+- **Location**: `.kittify/memory/` matches the Spec Kitty convention referenced by
+  `.kittify/missions/software-dev/command-templates/constitution.md` and by the
+  Constitution Check gate in `kitty-specs/002-daily-dap-quality-benchmarking/plan.md`.
+- **Gates as names**: Gates use stable snake_case identifiers (`tests_pass`,
+  `bdd_reviewed`, `documentation_updated`, `accessibility_reviewed`,
+  `methodology_reviewed`, `ai_disclosure_updated`) so reviews can record results
+  consistently in pull requests.
+- **BDD linkage**: The constitution and the `bdd_reviewed` gate both point at the
+  existing curated layer (`tests/bdd/features/`, `tests/bdd/TRACEABILITY.md`,
+  `tests/bdd/OWNERS.md`) rather than inventing a parallel structure.
+- **Retrospectives per mission**: Stored as `kitty-specs/<mission>/retrospective.md`
+  so institutional memory lives next to the mission it describes.
+- **No enforcement automation yet**: Gates are documented process, not CI checks.
+  Automating gate checks is listed as future work in `tasks.md`.
+
+## Risks
+
+- Governance documents can drift from practice. Mitigation: retrospectives include a
+  `governance_changes` field, and the amendment process keeps the constitution current.
+- Gates add review overhead. Mitigation: explicit n/a convention keeps small changes cheap.

--- a/kitty-specs/003-spec-kitty-governance-upgrade/spec.md
+++ b/kitty-specs/003-spec-kitty-governance-upgrade/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Spec Kitty Governance Upgrade
+
+**Feature Branch**: `003-spec-kitty-governance-upgrade`
+**Created**: 2026-07-10
+**Status**: Draft
+**Input**: Issue #210 "Adopt Current Spec Kitty Governance Model for Daily DAP"
+
+## Background
+
+Daily DAP was developed with Spec Kitty workflows and already contains substantial
+structure: `kitty-specs/002-daily-dap-quality-benchmarking/`, `.kittify/`, agent guidance
+(`AGENTS.md`, `.kittify/AGENTS.md`), BDD traceability (`tests/bdd/TRACEABILITY.md`,
+`tests/bdd/OWNERS.md`), and work package planning artifacts.
+
+The original mission plan explicitly skipped the constitution review because no
+constitution existed at the time (see the Constitution Check section of
+`kitty-specs/002-daily-dap-quality-benchmarking/plan.md`). As a result the repository has
+specification artifacts but lacks a binding governance layer. This mission adds that layer
+without disrupting the existing implementation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Binding Project Constitution (Priority: P1)
+
+As a maintainer or contributing agent, I can read a project constitution that defines the
+project's binding principles, so my work aligns with project values without rediscovering
+them from scattered documents.
+
+**Independent Test**: `.kittify/memory/constitution.md` exists, defines the principles
+listed in FR-001, and is referenced by mission planning conventions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new mission is planned, **When** the plan's Constitution Check gate runs,
+   **Then** a constitution exists at `.kittify/memory/constitution.md` and the gate can
+   evaluate compliance instead of being skipped.
+2. **Given** a proposed methodology change, **When** it is reviewed, **Then** the
+   constitution requires human review before the change affects published reports.
+
+### User Story 2 - Documented Review Gates (Priority: P1)
+
+As a reviewer, I can consult a documented review process with named gates, so approval
+decisions are consistent and auditable.
+
+**Independent Test**: `.kittify/memory/review-gates.md` exists and defines the gates
+`tests_pass`, `bdd_reviewed`, `documentation_updated`, `accessibility_reviewed`,
+`methodology_reviewed`, and `ai_disclosure_updated`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a work package is ready for review, **When** the reviewer applies the gates,
+   **Then** each gate has a documented pass condition and an n/a convention.
+2. **Given** a change to user-visible behavior, **When** the `bdd_reviewed` gate is
+   applied, **Then** it requires the curated behavior specifications and
+   `tests/bdd/TRACEABILITY.md` to be updated in the same change.
+
+### User Story 3 - Mission Retrospectives (Priority: P2)
+
+As a future contributor, I can read retrospectives from completed missions, so
+institutional memory survives across contributors and AI agents.
+
+**Independent Test**: `.kittify/memory/retrospective-template.md` exists with the standard
+fields (mission, completed, wins, surprises, mistakes, governance_changes, future_work),
+and the constitution requires a retrospective per completed mission.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mission completes, **When** the retrospective is written, **Then** it
+   follows the template and is stored at `kitty-specs/<mission>/retrospective.md`.
+
+### Edge Cases
+
+- What happens when a gate does not apply to a change? The reviewer records it as n/a
+  with a short reason, per `.kittify/memory/review-gates.md`.
+- What happens when a mission conflicts with the constitution? The constitution wins
+  unless an amendment is ratified first.
+- What happens when an AI agent proposes a constitution amendment? Agents may draft
+  amendments but a human maintainer must ratify them.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The project MUST have a constitution at `.kittify/memory/constitution.md`
+  defining, at minimum: accessibility as a primary quality metric, reproducibility of
+  published metrics, transparency of methodology, AI contribution disclosure, open
+  standards preference, human review for methodology changes, and public-interest
+  orientation.
+- **FR-002**: The project MUST document review gates at `.kittify/memory/review-gates.md`
+  covering tests, BDD review, documentation, accessibility, methodology, and AI
+  disclosure, and work MUST NOT move to approved status until applicable gates pass.
+- **FR-003**: Governance MUST require behavior specification review (curated Gherkin plus
+  traceability matrix) whenever user-visible behavior changes.
+- **FR-004**: The project MUST provide a standard retrospective template at
+  `.kittify/memory/retrospective-template.md`, and completed missions MUST produce a
+  retrospective stored in the mission directory.
+- **FR-005**: The constitution MUST define an amendment process with human ratification
+  and semantic versioning.
+- **FR-006**: Existing functionality and report outputs MUST remain unchanged; this
+  mission is documentation and governance only.
+
+## Non-Goals
+
+- Rewriting the existing implementation.
+- Replacing current specifications under `kitty-specs/001-*/` or `kitty-specs/002-*/`.
+- Introducing mandatory multi-agent orchestration.
+- Requiring Spec Kitty hosted services.
+- Changing existing report outputs.
+
+## Success Criteria
+
+- Constitution exists and is referenced by future missions.
+- Governance gates are documented.
+- Future missions follow a lifecycle model (specify, plan, tasks, implement, review,
+  accept, retrospective).
+- Retrospective template exists.
+- Review process explicitly covers accessibility, methodology, and AI disclosure.
+- Existing functionality remains unchanged (test suite still passes with no code changes).

--- a/kitty-specs/003-spec-kitty-governance-upgrade/tasks.md
+++ b/kitty-specs/003-spec-kitty-governance-upgrade/tasks.md
@@ -1,0 +1,67 @@
+---
+description: "Work packages for Spec Kitty Governance Upgrade"
+---
+
+# Work Packages: Spec Kitty Governance Upgrade
+
+**Inputs**: Design documents from `kitty-specs/003-spec-kitty-governance-upgrade/`
+**Prerequisites**: plan.md (required), spec.md
+
+**Tests**: No code changes; `npm test` must pass unchanged (FR-006). Deliverables are
+reviewed against the gates they define.
+
+**Organization**: Fine-grained subtasks (`Txxx`) roll up into work packages (`WPxx`).
+
+## Path Conventions
+
+- Governance memory: `.kittify/memory/`
+- Mission artifacts: `kitty-specs/003-spec-kitty-governance-upgrade/`
+- BDD layer: `tests/bdd/`
+
+---
+
+## Work Package WP01: Governance Foundation (Priority: P0)
+
+**Goal**: Establish the constitution, review gates, and retrospective template.
+**Independent Test**: All three files exist under `.kittify/memory/`, cover the
+principles and gates required by `spec.md` (FR-001, FR-002, FR-004, FR-005), and the
+existing test suite passes unchanged.
+
+### Included Subtasks
+
+- [x] T001 Create `.kittify/memory/constitution.md` with principles P1-P7, review-gate
+      reference, BDD linkage, retrospective requirement, mission conventions, and
+      amendment process.
+- [x] T002 Create `.kittify/memory/review-gates.md` defining tests_pass, bdd_reviewed,
+      documentation_updated, accessibility_reviewed, methodology_reviewed, and
+      ai_disclosure_updated, plus a recording convention.
+- [x] T003 Create `.kittify/memory/retrospective-template.md` with the standard fields
+      (mission, completed, wins, surprises, mistakes, governance_changes, future_work).
+- [x] T004 Create mission artifacts `spec.md`, `plan.md`, `tasks.md`, `meta.json` under
+      `kitty-specs/003-spec-kitty-governance-upgrade/`.
+- [x] T005 Update the `## AI Disclosure` section of `README.md` for this contribution.
+
+### Dependencies
+
+- None.
+
+---
+
+## Work Package WP02: Adoption and Enforcement (Priority: P2) - Future Work
+
+**Goal**: Put the governance layer into day-to-day practice.
+**Independent Test**: A subsequent mission completes its lifecycle using the gates and
+produces a retrospective.
+
+### Included Subtasks
+
+- [ ] T006 Apply the review gates to the next substantive pull request and record gate
+      results in the review.
+- [ ] T007 Write the first mission retrospective (retroactively for mission 002 or for
+      the next completed mission) at `kitty-specs/<mission>/retrospective.md`.
+- [ ] T008 Evaluate automating gate checks (for example a pull request template or CI
+      checklist) without making the process heavier than the project needs.
+
+### Dependencies
+
+- WP01 complete.

--- a/kitty-specs/003-spec-kitty-governance-upgrade/tasks/README.md
+++ b/kitty-specs/003-spec-kitty-governance-upgrade/tasks/README.md
@@ -1,0 +1,69 @@
+# Tasks Directory
+
+This directory contains work package (WP) prompt files with lane status in frontmatter.
+
+## Directory Structure (v0.9.0+)
+
+```
+tasks/
+├── WP01-setup-infrastructure.md
+├── WP02-user-authentication.md
+├── WP03-api-endpoints.md
+└── README.md
+```
+
+All WP files are stored flat in `tasks/`. The lane (planned, doing, for_review, done) is stored in the YAML frontmatter `lane:` field.
+
+## Work Package File Format
+
+Each WP file **MUST** use YAML frontmatter:
+
+```yaml
+---
+work_package_id: "WP01"
+title: "Work Package Title"
+lane: "planned"
+subtasks:
+  - "T001"
+  - "T002"
+phase: "Phase 1 - Setup"
+assignee: ""
+agent: ""
+shell_pid: ""
+review_status: ""
+reviewed_by: ""
+history:
+  - timestamp: "2025-01-01T00:00:00Z"
+    lane: "planned"
+    agent: "system"
+    action: "Prompt generated via /spec-kitty.tasks"
+---
+
+# Work Package Prompt: WP01 – Work Package Title
+
+[Content follows...]
+```
+
+## Valid Lane Values
+
+- `planned` - Ready for implementation
+- `doing` - Currently being worked on
+- `for_review` - Awaiting review
+- `done` - Completed
+
+## Moving Between Lanes
+
+Use the CLI (updates frontmatter only, no file movement):
+```bash
+spec-kitty agent tasks move-task <WPID> --to <lane>
+```
+
+Example:
+```bash
+spec-kitty agent tasks move-task WP01 --to doing
+```
+
+## File Naming
+
+- Format: `WP01-kebab-case-slug.md`
+- Examples: `WP01-setup-infrastructure.md`, `WP02-user-auth.md`

--- a/kitty-specs/003-spec-kitty-governance-upgrade/tasks/WP01-governance-foundation.md
+++ b/kitty-specs/003-spec-kitty-governance-upgrade/tasks/WP01-governance-foundation.md
@@ -1,0 +1,68 @@
+---
+work_package_id: WP01
+title: Governance Foundation
+lane: "for_review"
+dependencies: []
+base_branch: main
+base_commit: e8fc254c39b9759ac0d3906f20812e910ebb9708
+created_at: '2026-07-10T00:00:00.000000+00:00'
+subtasks:
+- T001
+- T002
+- T003
+- T004
+- T005
+phase: Phase 1 - Governance Foundation
+assignee: ''
+agent: "claude"
+shell_pid: ''
+review_status: "pending"
+reviewed_by: ''
+history:
+- timestamp: '2026-07-10T00:00:00Z'
+  lane: planned
+  agent: system
+  shell_pid: ''
+  action: Prompt generated for issue #210 governance upgrade
+- timestamp: '2026-07-10T00:00:00Z'
+  lane: for_review
+  agent: claude
+  shell_pid: ''
+  action: Governance documents authored; awaiting human review
+---
+
+# Work Package Prompt: WP01 - Governance Foundation
+
+## Objective
+
+Establish the binding governance layer described in issue #210 and
+`kitty-specs/003-spec-kitty-governance-upgrade/spec.md`: project constitution, review
+gates, and retrospective template, plus mission artifacts, without changing any runtime
+behavior or published report outputs.
+
+## Deliverables
+
+- `.kittify/memory/constitution.md` (T001)
+- `.kittify/memory/review-gates.md` (T002)
+- `.kittify/memory/retrospective-template.md` (T003)
+- `kitty-specs/003-spec-kitty-governance-upgrade/{spec.md,plan.md,tasks.md,meta.json}` (T004)
+- `README.md` AI Disclosure update (T005)
+
+## Constraints
+
+- Documentation only: no changes under `src/`, `tests/` behavior, or `docs/reports/`.
+- ASCII-safe UTF-8 and project-relative path references per `.kittify/AGENTS.md`.
+- `npm test` must pass unchanged.
+
+## Review Guidance
+
+Apply the gates defined in `.kittify/memory/review-gates.md`:
+
+- tests_pass: run `npm test`; no code changed, suite must be green.
+- bdd_reviewed: n/a (no user-visible behavior change to published reports).
+- documentation_updated: this work package is documentation; verify cross-references
+  resolve to real files.
+- accessibility_reviewed: n/a (no HTML output change).
+- methodology_reviewed: n/a (no methodology change).
+- ai_disclosure_updated: verify the `## AI Disclosure` table in `README.md` includes this
+  contribution.


### PR DESCRIPTION
## Summary

Implements issue #210 (Adopt Current Spec Kitty Governance Model for Daily DAP). Documentation-only change; no runtime code, tests, or published report outputs are modified.

- Adds `.kittify/memory/constitution.md`: binding project principles (accessibility as a primary quality metric, reproducibility of published metrics, methodology transparency, AI contribution disclosure, open standards preference, human review for methodology changes, public-interest orientation), plus BDD linkage, a per-mission retrospective requirement, mission lifecycle conventions, and a versioned amendment process (AI agents may draft amendments; only humans ratify).
- Adds `.kittify/memory/review-gates.md`: documents the six gates required before work moves to approved status (`tests_pass`, `bdd_reviewed`, `documentation_updated`, `accessibility_reviewed`, `methodology_reviewed`, `ai_disclosure_updated`) with pass conditions, an n/a convention, and a recording format for pull requests.
- Adds `.kittify/memory/retrospective-template.md`: standard retrospective format (mission, completed, wins, surprises, mistakes, governance_changes, future_work).
- Adds `kitty-specs/003-spec-kitty-governance-upgrade/`: mission artifacts (spec.md, plan.md with bootstrap Constitution Check, tasks.md, meta.json, tasks/WP01-governance-foundation.md marked `for_review`).
- Updates the `## AI Disclosure` section of `README.md` for this contribution.

Closes #210.

## Validation

- [x] `npm test` (411 pass / 14 fail; the same 14 failures occur on a clean checkout of `main` in the sandbox, so they are pre-existing and unrelated to this docs-only change)
- [x] `.kittify/scripts/validate_encoding.py` passes (ASCII-safe UTF-8 per `.kittify/AGENTS.md`)
- [x] Cross-references in the new documents resolve to real repository paths

## Behavior-driven development impact

- [x] I reviewed whether this change affects user-visible behavior (it does not; documentation and governance only)
- [x] I updated `tests/bdd/features/` scenarios as needed (n/a - no behavior change)
- [x] I updated `tests/bdd/TRACEABILITY.md` for new or changed requirements (n/a - no behavior change)

## Accessibility and security checks

- [x] HTML output changes still follow WCAG 2.2 AA expectations (n/a - no HTML output changes)
- [x] External or user-controlled content remains escaped where rendered (n/a - no rendering changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JomH4Pgh3j8A27oerxg4QX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JomH4Pgh3j8A27oerxg4QX)_